### PR TITLE
add prebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 build
+prebuilds/
+npm-debug.log

--- a/.prebuildrc
+++ b/.prebuildrc
@@ -1,0 +1,17 @@
+# abi 11
+# target[] = 0.10.40 FIXME!
+
+# abi 14
+target[] = 0.12.7
+
+# abi 42
+target[] = 1.0.4
+
+# abi 43
+target[] = 1.8.4
+
+# abi 44
+target[] = 2.4.0
+
+# abi 45
+target[] = 3.0.0

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Control a HackRF device (e.g. Jawbreaker, HackRF One, or Rad1o) from node",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "install": "prebuild --download",
+    "prebuild": "prebuild --verbose --upload"
   },
   "repository": {
     "type": "git",
@@ -26,7 +27,7 @@
     "bindings": "^1.2.1",
     "minimist": "^1.1.3",
     "nan": "^2.0.5",
-    "node-gyp": "^2.0.2"
+    "prebuild": "^2.3.4"
   },
   "gyp": true
 }


### PR DESCRIPTION
`npm run prebuild` to build `hackrf` for all major abi versions (except for `0.10.x` which has some issues) and upload to github

`npm install hackrf` should then download prebuild binaries from github

@mappum You need a github token in e.g. `~/.prebuildrc` @mafintosh obviously knows all the details :)
