### PR TITLE
Add prebuilds for node v4, v5, and v6

### DIFF
--- a/.prebuildrc
+++ b/.prebuildrc
@@ -15,3 +15,12 @@ target[] = 2.4.0
 
 # abi 45
 target[] = 3.0.0
+
+# abi 46
+target[] = 4.4.5
+
+# abi 47
+target[] = 5.11.1
+
+# abi 48
+target[] = 6.2.1


### PR DESCRIPTION
Adds targets to .prebuildrc for the latest versions of Node version 4, 5, and 6.

Tested with a HackRF One (`node bin.js --rxgraph`, worked without this PR after I downgraded to node/iojs v3.1.0, after these PR changes and rebuilt, with node v4.4.5, 5.11.1, and v6.2.1 installed with nvm). No other code changes were needed.
