### PR TITLE
Rename DEBUG environment variable to HACKRF_DEBUG

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-if (process.env.DEBUG) require('segfault-handler').registerHandler()
+if (process.env.HACKRF_DEBUG) require('segfault-handler').registerHandler()
 
 var hackrf = require('bindings')('hackrf')
 


### PR DESCRIPTION
Crashes the app if segfault-handler isn't installed, so better use something less generic.

The `DEBUG` environment variable is used a lot by general debugging modules (e.g. [debug](https://www.npmjs.com/package/debug)) and if used together with hackrf, this will crash the program unless the user have "segfault-handler" installed (which most people will not since it's not a dependency). So renaming the environment variable to something more unique to this module will probably save a lot of people some debugging time.