### PR TITLE
Fix device serial number extraction

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -29,10 +29,7 @@ void Devices(const FunctionCallbackInfo<Value>& info) {
     Local<Object> device = Nan::New<Object>();
     device->Set(Nan::New("boardId").ToLocalChecked(), Nan::New(list->usb_board_ids[i]));
     device->Set(Nan::New("usbIndex").ToLocalChecked(), Nan::New(list->usb_device_index[i]));
-
-    Local<Value> serialNumber = Nan::Null();
-    if(list->usb_device_index[i] != 0) serialNumber = Nan::New(list->usb_device_index[i]);
-    device->Set(Nan::New("serialNumber").ToLocalChecked(), serialNumber);
+    device->Set(Nan::New("serialNumber").ToLocalChecked(), Nan::New<String>(list->serial_numbers[i]).ToLocalChecked());
 
     devices->Set(i, device);
   }


### PR DESCRIPTION
Before:

```
> hackrf()
[ { boardId: 24713, usbIndex: 0, serialNumber: null },
  { boardId: 24713, usbIndex: 1, serialNumber: 1 },
  _open: [Function: _open],
  open: [Function] ]
```

Now:

```
> hackrf()
[ { boardId: 24713,
    usbIndex: 0,
    serialNumber: '0000000000000000a06063c8247aa95f' },
  { boardId: 24713,
    usbIndex: 1,
    serialNumber: '0000000000000000909864c839747fcf' },
  _open: [Function: _open],
  open: [Function] ]
```

Now the correct serial numbers are displaying 😃 