### PR TITLE
Expose device name as device.name

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -27,8 +27,11 @@ void Devices(const FunctionCallbackInfo<Value>& info) {
   Local<Array> devices = Nan::New<Array>(list->devicecount);
   for(int i = 0; i < list->devicecount; i++) {
     Local<Object> device = Nan::New<Object>();
+    enum hackrf_usb_board_id usb_board_id = list->usb_board_ids[i];
+    const char* name = hackrf_usb_board_id_name(usb_board_id);
+    device->Set(Nan::New("name").ToLocalChecked(), Nan::New<String>(name).ToLocalChecked());
     device->Set(Nan::New("usbIndex").ToLocalChecked(), Nan::New(list->usb_device_index[i]));
-    device->Set(Nan::New("usbBoardId").ToLocalChecked(), Nan::New(list->usb_board_ids[i]));
+    device->Set(Nan::New("usbBoardId").ToLocalChecked(), Nan::New(usb_board_id));
     device->Set(Nan::New("serialNumber").ToLocalChecked(), Nan::New<String>(list->serial_numbers[i]).ToLocalChecked());
 
     devices->Set(i, device);


### PR DESCRIPTION
Before:

```
> hackrf()
[ { usbIndex: 0,
    usbBoardId: 24713,
    serialNumber: '0000000000000000909864c839747fcf' },
  _open: [Function: _open],
  open: [Function] ]
```

After:

```
> hackrf()
[ { name: 'HackRF One',
    usbIndex: 0,
    usbBoardId: 24713,
    serialNumber: '0000000000000000909864c839747fcf' },
  _open: [Function: _open],
  open: [Function] ]
```