### PR TITLE
binding.gyp: update Mac OS deployment target to Mojave

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,7 @@
                     'xcode_settings': {
                         'OTHER_LDFLAGS': [ '-framework', 'CoreFoundation', '-framework', 'IOKit' ],
                         'SDKROOT': 'macosx',
-                        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+                        'MACOSX_DEPLOYMENT_TARGET': '10.14',
                     },
                 }]
             ]


### PR DESCRIPTION
Got it to compile on mac OS 10.14.3 (Mojave):
1. Install XCode from App Store
2. `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
3. Make this change to binding.gyp.